### PR TITLE
S.ieMode deprecated in Lift3, may use S.legacyIeCompatibilityMode

### DIFF
--- a/src/main/scala/code/config/ErrorHandler.scala
+++ b/src/main/scala/code/config/ErrorHandler.scala
@@ -22,7 +22,7 @@ object ErrorHandler extends Factory with Loggable {
           List("Content-Type" -> "text/html; charset=utf-8"),
           Nil,
           500,
-          S.ieMode
+          S.legacyIeCompatibilityMode
         )
       case (_, r, e) =>
         logException(r, e)


### PR DESCRIPTION
just a minor fix to the project to compile for the new Lift 3. By the way, thanks for the Lift 3 demo, is very cool !! (Y) :)
